### PR TITLE
feat(metrics): add more http metrics

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+# Reason for This PR
+
+`[Author TODO: add issue # or explain reasoning.]`
+
+## Description of Changes
+
+`[Author TODO: add description of changes.]`
+
+## License Acceptance
+
+By submitting this pull request, I confirm that my contribution is made under
+the terms of the MIT license.
+
+## PR Checklist
+
+`[Author TODO: Meet these criteria.]`
+`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`
+
+- [ ] All commits in this PR are signed (`git commit -s`).
+- [ ] The reason for this PR is clearly provided (issue no. or explanation).
+- [ ] The description of changes is clear and encompassing.
+- [ ] Any required documentation changes (code and docs) are included in this PR.
+- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
+- [ ] All added/changed functionality is tested.

--- a/metrics.go
+++ b/metrics.go
@@ -1,6 +1,8 @@
 package http
 
 import (
+	"strconv"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/roadrunner-server/api/v2/plugins/informer"
 )
@@ -10,20 +12,29 @@ func (p *Plugin) MetricsCollector() []prometheus.Collector {
 }
 
 type statsExporter struct {
-	desc    *prometheus.Desc
-	workers informer.Informer
+	totalMemoryDesc  *prometheus.Desc
+	stateDesc        *prometheus.Desc
+	workerMemoryDesc *prometheus.Desc
+	totalWorkersDesc *prometheus.Desc
+	workers          informer.Informer
 }
 
 func newWorkersExporter(stats informer.Informer) *statsExporter {
 	return &statsExporter{
-		desc:    prometheus.NewDesc("rr_http_workers_memory_bytes", "Memory usage by HTTP workers.", nil, nil),
-		workers: stats,
+		totalWorkersDesc: prometheus.NewDesc("rr_http_total_workers", "Total number of workers used by the HTTP plugin", nil, nil),
+		totalMemoryDesc:  prometheus.NewDesc("rr_http_workers_memory_bytes", "Memory usage by HTTP workers.", nil, nil),
+		stateDesc:        prometheus.NewDesc("rr_http_worker_state", "Worker current state", []string{"state", "pid"}, nil),
+		workerMemoryDesc: prometheus.NewDesc("rr_http_worker_memory_bytes", "Worker current memory usage", []string{"pid"}, nil),
+		workers:          stats,
 	}
 }
 
 func (s *statsExporter) Describe(d chan<- *prometheus.Desc) {
 	// send description
-	d <- s.desc
+	d <- s.totalWorkersDesc
+	d <- s.totalMemoryDesc
+	d <- s.stateDesc
+	d <- s.workerMemoryDesc
 }
 
 func (s *statsExporter) Collect(ch chan<- prometheus.Metric) {
@@ -36,8 +47,12 @@ func (s *statsExporter) Collect(ch chan<- prometheus.Metric) {
 	// collect the memory
 	for i := 0; i < len(workers); i++ {
 		cum += workers[i].MemoryUsage
+
+		ch <- prometheus.MustNewConstMetric(s.stateDesc, prometheus.GaugeValue, 0, workers[i].Status, strconv.Itoa(workers[i].Pid))
+		ch <- prometheus.MustNewConstMetric(s.workerMemoryDesc, prometheus.GaugeValue, float64(workers[i].MemoryUsage), strconv.Itoa(workers[i].Pid))
 	}
 
 	// send the values to the prometheus
-	ch <- prometheus.MustNewConstMetric(s.desc, prometheus.GaugeValue, float64(cum))
+	ch <- prometheus.MustNewConstMetric(s.totalWorkersDesc, prometheus.GaugeValue, float64(len(workers)))
+	ch <- prometheus.MustNewConstMetric(s.totalMemoryDesc, prometheus.GaugeValue, float64(cum))
 }


### PR DESCRIPTION
# Reason for This PR

- closes: https://github.com/roadrunner-server/roadrunner/issues/970

## Description of Changes

- Add new http metrics:
Worker's current state:
```
# HELP rr_http_worker_state Worker current state
# TYPE rr_http_worker_state gauge
rr_http_worker_state{pid="82885",state="ready"} 0
```

The total number of workers:
```
# HELP rr_http_total_workers Total number of workers used by the HTTP plugin
# TYPE rr_http_total_workers gauge
rr_http_total_workers 10
```
Particular worker memory usage:
```
# HELP rr_http_worker_memory_bytes Worker current memory usage
# TYPE rr_http_worker_memory_bytes gauge
rr_http_worker_memory_bytes{pid="82885"} 2.6218496e+07
```


## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.