### PR TITLE
fix: edge case where request has invalid multiple values for same field

### DIFF
--- a/handler/parse.go
+++ b/handler/parse.go
@@ -54,7 +54,7 @@ func invalidMultipleValuesErr(key string) error {
 
 func prepareNewDataNode(dt dataTree, i []string, v []string) (bool, error) {
 	if len(i) == 0 {
-		return false, errors.New("create new node with path traversal")
+		return false, errors.New("key indexes must not be empty")
 	}
 
 	_, ok := dt[i[0]]
@@ -136,8 +136,12 @@ func (dt dataTree) mount(i []string, v []string) error {
 		dt[i[0]] = v
 		return nil
 	}
-	if len(i) == 1 {
+	if len(i) == 1 && len(v) > 0 {
 		dt[i[0]] = v[len(v)-1]
+		return nil
+	}
+	if len(i) == 1 {
+		dt[i[0]] = v
 		return nil
 	}
 
@@ -178,7 +182,7 @@ func (ft fileTree) push(k string, v []*FileUpload) error {
 
 func prepareNewFileNode(ft fileTree, i []string, v []*FileUpload) (bool, error) {
 	if len(i) == 0 {
-		return false, errors.New("create new node with path traversal")
+		return false, errors.New("key indexes must not be empty")
 	}
 
 	_, ok := ft[i[0]]
@@ -235,8 +239,11 @@ func (ft fileTree) mount(i []string, v []*FileUpload) error {
 		// non associated array of elements
 		ft[i[0]] = v
 		return nil
-	case len(i) == 1:
+	case len(i) == 1 && len(v) > 0:
 		ft[i[0]] = v[0]
+		return nil
+	case len(i) == 1:
+		ft[i[0]] = v
 		return nil
 	}
 

--- a/handler/parse.go
+++ b/handler/parse.go
@@ -92,6 +92,32 @@ func prepareNewDataNode(dt dataTree, i []string, v []string) (bool, error) {
 }
 
 // mount mounts data tree recursively.
+//
+// # This can handle this edge case
+// # Assume that we have the following POST data
+//
+// _token: NM8eor1JFGRLxfaTNHanGX4en0ZMFtatdz1Muu5Z
+// _method: PUT
+// _http_referrer: http://localhost/admin/article
+// name: Rerum non omnis dicta occaecati dignissimos culpa commodi.
+// category_id: 97b64555-f825-4ca0-927f-4f8da03cdb31
+// options:
+// options[0][id]: 97b64557-24ad-4099-88f2-0d275874d2e8
+// options[0][order_priority]: 1000
+// options[0][name]: Adipisci eaque vero laborum reprehenderit id ipsam deserunt.
+// options[1][id]: 97b64557-2699-4b60-959e-641370c399a7
+// options[1][order_priority]: 1000
+// options[1][name]: Facere laudantium quos sunt eius eveniet est.
+// options[2][id]: 97b64557-28bf-43c2-99bb-be96358a7d8b
+// options[2][order_priority]: 1001
+// options[2][name]: Perferendis et molestiae minus id cupiditate amet dolores.
+// description: Et repudiandae voluptatem aspernatur eum et. Facere et harum cum corporis. Quis assumenda est iusto accusantium. Aliquam autem natus non voluptates.
+// id: 97b64557-19ba-49bd-bdec-783e32fbc6e8
+// _save_action: save_and_back
+//
+// # If we don't ignore empty options we will lose the whole array of data in key options[x]
+// # So we will ignore it and process the array of data in options[x] if those present in the request.
+// # Same is done for fileTree data structure underneath
 func (dt dataTree) mount(i []string, v []string) error {
 	if len(i) == 0 {
 		return nil

--- a/handler/parse.go
+++ b/handler/parse.go
@@ -45,6 +45,15 @@ func (dt dataTree) push(k string, v []string) error {
 	return nil
 }
 
+func errWhenCreateNode(tree any, keys []string, value any) error {
+	return fmt.Errorf(
+		"invalid value in tree. key: %+v, val: %+v, tree: %+v",
+		keys[0],
+		value,
+		tree,
+	)
+}
+
 func prepareNewDataNode(dt dataTree, i []string, v []string) (bool, error) {
 	if len(i) == 0 {
 		return false, errors.New("should not prepare new node")
@@ -55,13 +64,6 @@ func prepareNewDataNode(dt dataTree, i []string, v []string) (bool, error) {
 		dt[i[0]] = make(dataTree)
 		return true, nil
 	}
-
-	potentialErr := fmt.Errorf(
-		"invalid value in dataTree. key: %+v, val: %+v, tree: %+v",
-		i[0],
-		v,
-		dt,
-	)
 
 	_, dataTreeOK := dt[i[0]].(dataTree)
 	if !dataTreeOK {
@@ -77,7 +79,7 @@ func prepareNewDataNode(dt dataTree, i []string, v []string) (bool, error) {
 				return true, nil
 			}
 		}
-		return false, potentialErr
+		return false, errWhenCreateNode(dt, i, v)
 	}
 
 	if len(i) > 1 {
@@ -88,7 +90,7 @@ func prepareNewDataNode(dt dataTree, i []string, v []string) (bool, error) {
 		return false, nil
 	}
 
-	return false, potentialErr
+	return false, errWhenCreateNode(dt, i, v)
 }
 
 // mount mounts data tree recursively.
@@ -191,13 +193,6 @@ func prepareNewFileNode(ft fileTree, i []string, v []*FileUpload) (bool, error) 
 		return true, nil
 	}
 
-	potentialErr := fmt.Errorf(
-		"invalid value in fileTree. key: %+v, val: %+v, tree: %+v",
-		i[0],
-		v,
-		ft,
-	)
-
 	_, fileTreeOK := ft[i[0]].(fileTree)
 	if !fileTreeOK {
 		switch oldV := ft[i[0]].(type) {
@@ -213,7 +208,7 @@ func prepareNewFileNode(ft fileTree, i []string, v []*FileUpload) (bool, error) 
 			}
 		}
 
-		return false, potentialErr
+		return false, errWhenCreateNode(ft, i, v)
 	}
 
 	if len(i) > 1 {
@@ -224,7 +219,7 @@ func prepareNewFileNode(ft fileTree, i []string, v []*FileUpload) (bool, error) 
 		return false, nil
 	}
 
-	return false, potentialErr
+	return false, errWhenCreateNode(ft, i, v)
 }
 
 // mount mounts data tree recursively.

--- a/handler/parse.go
+++ b/handler/parse.go
@@ -67,16 +67,23 @@ func prepareNewDataNode(dt dataTree, i []string, v []string) (bool, error) {
 	if !dataTreeOK {
 		switch oldV := dt[i[0]].(type) {
 		case string:
-			if len(oldV) == 0 {
+			if len(oldV) == 0 && len(i) > 1 {
 				dt[i[0]] = make(dataTree)
 				return true, nil
 			}
 		case []string:
-			if len(oldV) == 0 {
+			if len(oldV) == 0 && len(i) > 1 {
 				dt[i[0]] = make(dataTree)
 				return true, nil
 			}
 		}
+		if len(i) == 2 && i[1] == "" {
+			return true, nil
+		}
+		if len(i) == 1 {
+			return true, nil
+		}
+
 		return false, invalidMultipleValuesErr(i[0])
 	}
 
@@ -93,31 +100,23 @@ func prepareNewDataNode(dt dataTree, i []string, v []string) (bool, error) {
 
 // mount mounts data tree recursively.
 //
-// # This can handle this edge case
-// # Assume that we have the following POST data
+// This can handle this edge case
+// Assume that we have the following POST data
 //
 // _token: NM8eor1JFGRLxfaTNHanGX4en0ZMFtatdz1Muu5Z
 // _method: PUT
 // _http_referrer: http://localhost/admin/article
 // name: Rerum non omnis dicta occaecati dignissimos culpa commodi.
-// category_id: 97b64555-f825-4ca0-927f-4f8da03cdb31
 // options:
 // options[0][id]: 97b64557-24ad-4099-88f2-0d275874d2e8
 // options[0][order_priority]: 1000
 // options[0][name]: Adipisci eaque vero laborum reprehenderit id ipsam deserunt.
-// options[1][id]: 97b64557-2699-4b60-959e-641370c399a7
-// options[1][order_priority]: 1000
-// options[1][name]: Facere laudantium quos sunt eius eveniet est.
-// options[2][id]: 97b64557-28bf-43c2-99bb-be96358a7d8b
-// options[2][order_priority]: 1001
-// options[2][name]: Perferendis et molestiae minus id cupiditate amet dolores.
-// description: Et repudiandae voluptatem aspernatur eum et. Facere et harum cum corporis. Quis assumenda est iusto accusantium. Aliquam autem natus non voluptates.
 // id: 97b64557-19ba-49bd-bdec-783e32fbc6e8
 // _save_action: save_and_back
 //
-// # If we don't ignore empty options we will lose the whole array of data in key options[x]
-// # So we will ignore it and process the array of data in options[x] if those present in the request.
-// # Same is done for fileTree data structure underneath
+// If we don't ignore empty options we will lose the whole array of data in key options[x]
+// So we will ignore it and process the array of data in options[x] if those present in the request.
+// Same is done for fileTree data structure underneath
 func (dt dataTree) mount(i []string, v []string) error {
 	if len(i) == 0 {
 		return nil
@@ -195,15 +194,21 @@ func prepareNewFileNode(ft fileTree, i []string, v []*FileUpload) (bool, error) 
 	if !fileTreeOK {
 		switch oldV := ft[i[0]].(type) {
 		case *FileUpload:
-			if oldV == nil {
+			if oldV == nil && len(i) > 1 {
 				ft[i[0]] = make(fileTree)
 				return true, nil
 			}
 		case []*FileUpload:
-			if len(oldV) == 0 {
+			if len(oldV) == 0 && len(i) > 1 {
 				ft[i[0]] = make(fileTree)
 				return true, nil
 			}
+		}
+		if len(i) == 2 && i[1] == "" {
+			return true, nil
+		}
+		if len(i) == 1 {
+			return true, nil
 		}
 
 		return false, invalidMultipleValuesErr(i[0])

--- a/handler/parse.go
+++ b/handler/parse.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 )
@@ -53,10 +52,6 @@ func invalidMultipleValuesErr(key string) error {
 }
 
 func prepareNewDataNode(dt dataTree, i []string, v []string) (bool, error) {
-	if len(i) == 0 {
-		return false, errors.New("key indexes must not be empty")
-	}
-
 	_, ok := dt[i[0]]
 	if !ok {
 		dt[i[0]] = make(dataTree)
@@ -180,10 +175,6 @@ func (ft fileTree) push(k string, v []*FileUpload) error {
 }
 
 func prepareNewFileNode(ft fileTree, i []string, v []*FileUpload) (bool, error) {
-	if len(i) == 0 {
-		return false, errors.New("key indexes must not be empty")
-	}
-
 	_, ok := ft[i[0]]
 	if !ok {
 		ft[i[0]] = make(fileTree)

--- a/handler/parse.go
+++ b/handler/parse.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 )
@@ -12,35 +13,42 @@ type dataTree map[string]any
 type fileTree map[string]any
 
 // parseData parses incoming request body into data tree.
-func parseData(r *http.Request) dataTree {
+func parseData(r *http.Request) (dataTree, error) {
 	data := make(dataTree)
 	if r.PostForm != nil {
 		for k, v := range r.PostForm {
-			data.push(k, v)
+			err := data.push(k, v)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
 	if r.MultipartForm != nil {
 		for k, v := range r.MultipartForm.Value {
-			data.push(k, v)
+			err := data.push(k, v)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
-	return data
+	return data, nil
 }
 
 // pushes value into data tree.
-func (d dataTree) push(k string, v []string) {
+func (d dataTree) push(k string, v []string) error {
 	keys := fetchIndexes(k)
 	if len(keys) <= MaxLevel {
-		d.mount(keys, v)
+		return d.mount(keys, v)
 	}
+	return nil
 }
 
 // mount mounts data tree recursively.
-func (d dataTree) mount(i []string, v []string) {
+func (d dataTree) mount(i []string, v []string) error {
 	if len(i) == 0 {
-		return
+		return nil
 	}
 
 	p, ok := d[i[0]]
@@ -55,7 +63,7 @@ func (d dataTree) mount(i []string, v []string) {
 			} else if stringArrayOk && len(oldVStringArray) == 0 {
 				d[i[0]] = make(dataTree)
 			} else {
-				panic(
+				return errors.New(
 					fmt.Sprintf(
 						"invalid value in dataTree. key: %+v, val: %+v, tree: %+v",
 						i[0],
@@ -66,7 +74,7 @@ func (d dataTree) mount(i []string, v []string) {
 			}
 		}
 		if dataTreeOK && len(i) == 1 && (len(v) == 0 || len(v[0]) == 0) {
-			return
+			return nil
 		}
 	} else {
 		d[i[0]] = make(dataTree)
@@ -75,23 +83,23 @@ func (d dataTree) mount(i []string, v []string) {
 	if len(i) == 2 && i[1] == "" {
 		// non associated array of elements
 		d[i[0]] = v
-		return
+		return nil
 	}
 
 	if len(i) == 1 {
 		if len(v) == 1 {
 			d[i[0]] = v[0]
-			return
+			return nil
 		}
 		d[i[0]] = v
-		return
+		return nil
 	}
 
-	d[i[0]].(dataTree).mount(i[1:], v)
+	return d[i[0]].(dataTree).mount(i[1:], v)
 }
 
 // parse incoming dataTree request into JSON (including contentMultipart form dataTree)
-func parseUploads(r *http.Request, uid, gid int) *Uploads {
+func parseUploads(r *http.Request, uid, gid int) (*Uploads, error) {
 	u := &Uploads{
 		tree: make(fileTree),
 		list: make([]*FileUpload, 0),
@@ -104,24 +112,28 @@ func parseUploads(r *http.Request, uid, gid int) *Uploads {
 		}
 
 		u.list = append(u.list, files...)
-		u.tree.push(k, files)
+		err := u.tree.push(k, files)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return u
+	return u, nil
 }
 
 // pushes new file upload into it's proper place.
-func (d fileTree) push(k string, v []*FileUpload) {
+func (d fileTree) push(k string, v []*FileUpload) error {
 	keys := fetchIndexes(k)
 	if len(keys) <= MaxLevel {
-		d.mount(keys, v)
+		return d.mount(keys, v)
 	}
+	return nil
 }
 
 // mount mounts data tree recursively.
-func (d fileTree) mount(i []string, v []*FileUpload) {
+func (d fileTree) mount(i []string, v []*FileUpload) error {
 	if len(i) == 0 {
-		return
+		return nil
 	}
 
 	p, ok := d[i[0]]
@@ -136,7 +148,7 @@ func (d fileTree) mount(i []string, v []*FileUpload) {
 			} else if fileUploadArrayOK && len(oldVFileUploadArray) == 0 {
 				d[i[0]] = make(fileTree)
 			} else {
-				panic(
+				return errors.New(
 					fmt.Sprintf(
 						"invalid value in fileTree. key: %+v, val: %+v, tree: %+v",
 						i[0],
@@ -147,7 +159,7 @@ func (d fileTree) mount(i []string, v []*FileUpload) {
 			}
 		}
 		if fileTreeOK && len(i) == 1 && (len(v) == 0 || v[0] == nil) {
-			return
+			return nil
 		}
 	} else {
 		d[i[0]] = make(fileTree)
@@ -156,19 +168,19 @@ func (d fileTree) mount(i []string, v []*FileUpload) {
 	if len(i) == 2 && i[1] == "" {
 		// non associated array of elements
 		d[i[0]] = v
-		return
+		return nil
 	}
 
 	if len(i) == 1 {
 		if len(v) == 1 {
 			d[i[0]] = v[0]
-			return
+			return nil
 		}
 		d[i[0]] = v
-		return
+		return nil
 	}
 
-	d[i[0]].(fileTree).mount(i[1:], v)
+	return d[i[0]].(fileTree).mount(i[1:], v)
 }
 
 // fetchIndexes parses input name and splits it into separate indexes list.

--- a/handler/parse.go
+++ b/handler/parse.go
@@ -45,18 +45,16 @@ func (dt dataTree) push(k string, v []string) error {
 	return nil
 }
 
-func errWhenCreateNode(tree any, keys []string, value any) error {
+func invalidMultipleValuesErr(key string) error {
 	return fmt.Errorf(
-		"invalid value in tree. key: %+v, val: %+v, tree: %+v",
-		keys[0],
-		value,
-		tree,
+		"invalid multiple values to key '%+v' in tree",
+		key,
 	)
 }
 
 func prepareNewDataNode(dt dataTree, i []string, v []string) (bool, error) {
 	if len(i) == 0 {
-		return false, errors.New("should not prepare new node")
+		return false, errors.New("create new node with path traversal")
 	}
 
 	_, ok := dt[i[0]]
@@ -79,7 +77,7 @@ func prepareNewDataNode(dt dataTree, i []string, v []string) (bool, error) {
 				return true, nil
 			}
 		}
-		return false, errWhenCreateNode(dt, i, v)
+		return false, invalidMultipleValuesErr(i[0])
 	}
 
 	if len(i) > 1 {
@@ -90,7 +88,7 @@ func prepareNewDataNode(dt dataTree, i []string, v []string) (bool, error) {
 		return false, nil
 	}
 
-	return false, errWhenCreateNode(dt, i, v)
+	return false, invalidMultipleValuesErr(i[0])
 }
 
 // mount mounts data tree recursively.
@@ -184,7 +182,7 @@ func (ft fileTree) push(k string, v []*FileUpload) error {
 
 func prepareNewFileNode(ft fileTree, i []string, v []*FileUpload) (bool, error) {
 	if len(i) == 0 {
-		return false, errors.New("should not prepare new node")
+		return false, errors.New("create new node with path traversal")
 	}
 
 	_, ok := ft[i[0]]
@@ -208,7 +206,7 @@ func prepareNewFileNode(ft fileTree, i []string, v []*FileUpload) (bool, error) 
 			}
 		}
 
-		return false, errWhenCreateNode(ft, i, v)
+		return false, invalidMultipleValuesErr(i[0])
 	}
 
 	if len(i) > 1 {
@@ -219,7 +217,7 @@ func prepareNewFileNode(ft fileTree, i []string, v []*FileUpload) (bool, error) 
 		return false, nil
 	}
 
-	return false, errWhenCreateNode(ft, i, v)
+	return false, invalidMultipleValuesErr(i[0])
 }
 
 // mount mounts data tree recursively.

--- a/handler/parse.go
+++ b/handler/parse.go
@@ -136,12 +136,8 @@ func (dt dataTree) mount(i []string, v []string) error {
 		dt[i[0]] = v
 		return nil
 	}
-	if len(i) == 1 && len(v) == 1 {
-		dt[i[0]] = v[0]
-		return nil
-	}
 	if len(i) == 1 {
-		dt[i[0]] = v
+		dt[i[0]] = v[len(v)-1]
 		return nil
 	}
 
@@ -239,11 +235,8 @@ func (ft fileTree) mount(i []string, v []*FileUpload) error {
 		// non associated array of elements
 		ft[i[0]] = v
 		return nil
-	case len(i) == 1 && len(v) == 1:
-		ft[i[0]] = v[0]
-		return nil
 	case len(i) == 1:
-		ft[i[0]] = v
+		ft[i[0]] = v[0]
 		return nil
 	}
 

--- a/handler/parse_test.go
+++ b/handler/parse_test.go
@@ -58,9 +58,6 @@ func TestPushWithMultipleLevelPostDataNoErr(t *testing.T) {
 		"id": []string{
 			"97b27435-38e3-44d2-b97b-89d82fd6c212",
 		},
-		"options": []string{
-			"",
-		},
 		"options[0][id]": []string{
 			"97b27435-3cb7-40f1-9637-e406465e63ed",
 		},
@@ -90,9 +87,15 @@ func TestPushWithMultipleLevelPostDataNoErr(t *testing.T) {
 		},
 	}
 
+	// request has empty plain value to same key
+	// which will have structured value later
 	d := make(dataTree)
+	err := d.push("options", []string{""})
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
 	for k, v := range postForm {
-		err := d.push(k, v)
+		err = d.push(k, v)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -106,15 +109,40 @@ func TestPushWithMultipleLevelPostDataNoErr(t *testing.T) {
 			t.Fatalf("invalid length of options[%s]: %+v", k, v)
 		}
 	}
+
+	// request has empty array value to a key,
+	// which will have structured value later
+	d = make(dataTree)
+	err = d.push("options[]", []string{})
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	for k, v := range postForm {
+		err = d.push(k, v)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// request has empty array value to a key,
+	// which previously have structured value
+	d = make(dataTree)
+	for k, v := range postForm {
+		err = d.push(k, v)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	err = d.push("options[]", []string{})
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
 }
 
 func TestPushWithMultipleLevelPostDataWithErr(t *testing.T) {
 	postForm := url.Values{
 		"id": []string{
 			"97b27435-38e3-44d2-b97b-89d82fd6c212",
-		},
-		"options": []string{
-			"invalid-data",
 		},
 		"options[0][id]": []string{
 			"97b27435-3cb7-40f1-9637-e406465e63ed",
@@ -149,6 +177,23 @@ func TestPushWithMultipleLevelPostDataWithErr(t *testing.T) {
 		d   = make(dataTree)
 		err error
 	)
+	for k, v := range postForm {
+		err = d.push(k, v)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+	}
+	err = d.push("options", []string{"invalid-data"})
+	if err == nil {
+		t.Fatal("there should have error")
+	}
+	t.Logf("got err: %+v", err)
+
+	d = make(dataTree)
+	err = d.push("options", []string{"invalid-data"})
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
 	for k, v := range postForm {
 		err = d.push(k, v)
 		if err != nil {

--- a/handler/parse_test.go
+++ b/handler/parse_test.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"fmt"
 	"net/url"
 	"testing"
 )
@@ -100,11 +99,11 @@ func TestPushWithMultipleLevelPostDataNoErr(t *testing.T) {
 	}
 	optionDataTree := d["options"].(dataTree)
 	if len(optionDataTree) != 3 {
-		t.Fatal(fmt.Sprintf("invalid length of options: %+v", optionDataTree))
+		t.Fatalf("invalid length of options: %+v", optionDataTree)
 	}
 	for k, v := range optionDataTree {
 		if len(v.(dataTree)) != 3 {
-			t.Fatal(fmt.Sprintf("invalid length of options[%s]: %+v", k, v))
+			t.Fatalf("invalid length of options[%s]: %+v", k, v)
 		}
 	}
 }
@@ -207,11 +206,11 @@ func TestPushWithMultipleLevelFileUploadNoErr(t *testing.T) {
 	}
 	optionFileTree := d["options"].(fileTree)
 	if len(optionFileTree) != 2 {
-		t.Fatal(fmt.Sprintf("invalid length of options: %+v", optionFileTree))
+		t.Fatalf("invalid length of options: %+v", optionFileTree)
 	}
 	for k, v := range optionFileTree {
 		if len(v.(fileTree)) != 3 {
-			t.Fatal(fmt.Sprintf("invalid length of options[%s]: %+v", k, d))
+			t.Fatalf("invalid length of options[%s]: %+v", k, d)
 		}
 	}
 }

--- a/handler/parse_test.go
+++ b/handler/parse_test.go
@@ -54,7 +54,7 @@ func same(in, out []string) bool {
 	return true
 }
 
-func TestPushWithMultipleLevelPostData(t *testing.T) {
+func TestPushWithMultipleLevelPostDataNoErr(t *testing.T) {
 	postForm := url.Values{
 		"id": []string{
 			"97b27435-38e3-44d2-b97b-89d82fd6c212",
@@ -93,7 +93,10 @@ func TestPushWithMultipleLevelPostData(t *testing.T) {
 
 	d := make(dataTree)
 	for k, v := range postForm {
-		d.push(k, v)
+		err := d.push(k, v)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 	optionDataTree := d["options"].(dataTree)
 	if len(optionDataTree) != 3 {
@@ -106,7 +109,60 @@ func TestPushWithMultipleLevelPostData(t *testing.T) {
 	}
 }
 
-func TestPushWithMultipleLevelFileUpload(t *testing.T) {
+func TestPushWithMultipleLevelPostDataWithErr(t *testing.T) {
+	postForm := url.Values{
+		"id": []string{
+			"97b27435-38e3-44d2-b97b-89d82fd6c212",
+		},
+		"options": []string{
+			"invalid-data",
+		},
+		"options[0][id]": []string{
+			"97b27435-3cb7-40f1-9637-e406465e63ed",
+		},
+		"options[0][name]": []string{
+			"Reiciendis et impedit quod id.",
+		},
+		"options[0][value]": []string{
+			"",
+		},
+		"options[1][id]": []string{
+			"97b27435-3d8a-4f68-b034-88ef3b6cd161",
+		},
+		"options[1][name]": []string{
+			"Mollitia aut assumenda non tempora.",
+		},
+		"options[1][value]": []string{
+			"",
+		},
+		"options[2][id]": []string{
+			"97b27435-3e5a-461a-abee-3c7b3d50ef14",
+		},
+		"options[2][value]": []string{
+			"",
+		},
+		"options[2][name]": []string{
+			"Libero ipsa doloremque non rerum enim.",
+		},
+	}
+
+	var (
+		d   = make(dataTree)
+		err error
+	)
+	for k, v := range postForm {
+		err = d.push(k, v)
+		if err != nil {
+			break
+		}
+	}
+	if err == nil {
+		t.Fatal("there should have error")
+	}
+	t.Logf("got err: %+v", err)
+}
+
+func TestPushWithMultipleLevelFileUploadNoErr(t *testing.T) {
 	postForm := map[string][]*FileUpload{
 		"id": {
 			&FileUpload{
@@ -144,7 +200,10 @@ func TestPushWithMultipleLevelFileUpload(t *testing.T) {
 
 	d := make(fileTree)
 	for k, v := range postForm {
-		d.push(k, v)
+		err := d.push(k, v)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 	optionFileTree := d["options"].(fileTree)
 	if len(optionFileTree) != 2 {
@@ -155,4 +214,60 @@ func TestPushWithMultipleLevelFileUpload(t *testing.T) {
 			t.Fatal(fmt.Sprintf("invalid length of options[%s]: %+v", k, d))
 		}
 	}
+}
+
+func TestPushWithMultipleLevelFileUploadWithErr(t *testing.T) {
+	postForm := map[string][]*FileUpload{
+		"id": {
+			&FileUpload{
+				Name: "file-upload-id",
+			},
+		},
+		"options": {
+			&FileUpload{
+				Name: "file-upload-root-options",
+			},
+		},
+		"options[0][id]": {
+			&FileUpload{
+				Name: "file-upload-0-id",
+			},
+		},
+		"options[0][name]": {
+			&FileUpload{
+				Name: "file-upload-0-name",
+			},
+		},
+		"options[0][value]": {
+			nil,
+		},
+		"options[1][id]": {
+			&FileUpload{
+				Name: "file-upload-1-id",
+			},
+		},
+		"options[1][name]": {
+			&FileUpload{
+				Name: "file-upload-1-name",
+			},
+		},
+		"options[1][value]": {
+			nil,
+		},
+	}
+
+	var (
+		d   = make(fileTree)
+		err error
+	)
+	for k, v := range postForm {
+		err = d.push(k, v)
+		if err != nil {
+			break
+		}
+	}
+	if err == nil {
+		t.Fatal("there should have error")
+	}
+	t.Logf("got err: %+v", err)
 }

--- a/handler/parse_test.go
+++ b/handler/parse_test.go
@@ -61,6 +61,7 @@ func TestPushWithOneLevelPostWithOverwrite(t *testing.T) {
 	form.Add("name[]", "name1")
 	form.Add("name[]", "name2")
 	form.Add("name[]", "name3")
+	form.Add("arr", "")
 	form.Add("arr[x][y][z]", "y")
 	form.Add("arr[x][y][e]", "f")
 	form.Add("arr[c]p", "l")
@@ -87,6 +88,9 @@ func TestPushWithMultipleLevelPostDataNoErr(t *testing.T) {
 		"id": []string{
 			"97b27435-38e3-44d2-b97b-89d82fd6c212",
 		},
+		"names[]": []string{
+			"name1", "names2",
+		},
 		"options[0][id]": []string{
 			"97b27435-3cb7-40f1-9637-e406465e63ed",
 		},
@@ -94,15 +98,6 @@ func TestPushWithMultipleLevelPostDataNoErr(t *testing.T) {
 			"Reiciendis et impedit quod id.",
 		},
 		"options[0][value]": []string{
-			"",
-		},
-		"options[1][id]": []string{
-			"97b27435-3d8a-4f68-b034-88ef3b6cd161",
-		},
-		"options[1][name]": []string{
-			"Mollitia aut assumenda non tempora.",
-		},
-		"options[1][value]": []string{
 			"",
 		},
 	}
@@ -121,7 +116,7 @@ func TestPushWithMultipleLevelPostDataNoErr(t *testing.T) {
 		}
 	}
 	optionDataTree := d["options"].(dataTree)
-	if len(optionDataTree) != 2 {
+	if len(optionDataTree) != 1 {
 		t.Fatalf("invalid length of options: %+v", optionDataTree)
 	}
 	for k, v := range optionDataTree {
@@ -171,15 +166,6 @@ func TestPushWithMultipleLevelPostDataWithErr(t *testing.T) {
 			"Reiciendis et impedit quod id.",
 		},
 		"options[0][value]": []string{
-			"",
-		},
-		"options[1][id]": []string{
-			"97b27435-3d8a-4f68-b034-88ef3b6cd161",
-		},
-		"options[1][name]": []string{
-			"Mollitia aut assumenda non tempora.",
-		},
-		"options[1][value]": []string{
 			"",
 		},
 	}
@@ -238,19 +224,6 @@ func TestPushWithMultipleLevelFileUploadNoErr(t *testing.T) {
 		"options[0][value]": {
 			nil,
 		},
-		"options[1][id]": {
-			&FileUpload{
-				Name: "file-upload-1-id",
-			},
-		},
-		"options[1][name]": {
-			&FileUpload{
-				Name: "file-upload-1-name",
-			},
-		},
-		"options[1][value]": {
-			nil,
-		},
 	}
 
 	d := make(fileTree)
@@ -261,7 +234,7 @@ func TestPushWithMultipleLevelFileUploadNoErr(t *testing.T) {
 		}
 	}
 	optionFileTree := d["options"].(fileTree)
-	if len(optionFileTree) != 2 {
+	if len(optionFileTree) != 1 {
 		t.Fatalf("invalid length of options: %+v", optionFileTree)
 	}
 	for k, v := range optionFileTree {
@@ -276,6 +249,14 @@ func TestPushWithMultipleLevelFileUploadWithErr(t *testing.T) {
 		"id": {
 			&FileUpload{
 				Name: "file-upload-id",
+			},
+		},
+		"names[]": {
+			&FileUpload{
+				Name: "file-upload-names-1",
+			},
+			&FileUpload{
+				Name: "file-upload-names-1",
 			},
 		},
 		"options": {
@@ -294,19 +275,6 @@ func TestPushWithMultipleLevelFileUploadWithErr(t *testing.T) {
 			},
 		},
 		"options[0][value]": {
-			nil,
-		},
-		"options[1][id]": {
-			&FileUpload{
-				Name: "file-upload-1-id",
-			},
-		},
-		"options[1][name]": {
-			&FileUpload{
-				Name: "file-upload-1-name",
-			},
-		},
-		"options[1][value]": {
 			nil,
 		},
 	}

--- a/handler/parse_test.go
+++ b/handler/parse_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"net/url"
+	"reflect"
 	"testing"
 )
 
@@ -53,6 +54,34 @@ func same(in, out []string) bool {
 	return true
 }
 
+func TestPushWithOneLevelPostWithOverwrite(t *testing.T) {
+	form := url.Values{}
+	form.Add("key", "value")
+	form.Add("key", "value2")
+	form.Add("name[]", "name1")
+	form.Add("name[]", "name2")
+	form.Add("name[]", "name3")
+	form.Add("arr[x][y][z]", "y")
+	form.Add("arr[x][y][e]", "f")
+	form.Add("arr[c]p", "l")
+	form.Add("arr[c]z", "")
+
+	var (
+		d   = make(dataTree)
+		err error
+	)
+	for k, v := range form {
+		err = d.push(k, v)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if !reflect.DeepEqual(d["key"], "value2") {
+		t.Fatalf("overwriting expected. tree is %+v", d)
+	}
+}
+
 func TestPushWithMultipleLevelPostDataNoErr(t *testing.T) {
 	postForm := url.Values{
 		"id": []string{
@@ -76,15 +105,6 @@ func TestPushWithMultipleLevelPostDataNoErr(t *testing.T) {
 		"options[1][value]": []string{
 			"",
 		},
-		"options[2][id]": []string{
-			"97b27435-3e5a-461a-abee-3c7b3d50ef14",
-		},
-		"options[2][value]": []string{
-			"",
-		},
-		"options[2][name]": []string{
-			"Libero ipsa doloremque non rerum enim.",
-		},
 	}
 
 	// request has empty plain value to same key
@@ -101,7 +121,7 @@ func TestPushWithMultipleLevelPostDataNoErr(t *testing.T) {
 		}
 	}
 	optionDataTree := d["options"].(dataTree)
-	if len(optionDataTree) != 3 {
+	if len(optionDataTree) != 2 {
 		t.Fatalf("invalid length of options: %+v", optionDataTree)
 	}
 	for k, v := range optionDataTree {
@@ -161,15 +181,6 @@ func TestPushWithMultipleLevelPostDataWithErr(t *testing.T) {
 		},
 		"options[1][value]": []string{
 			"",
-		},
-		"options[2][id]": []string{
-			"97b27435-3e5a-461a-abee-3c7b3d50ef14",
-		},
-		"options[2][value]": []string{
-			"",
-		},
-		"options[2][name]": []string{
-			"Libero ipsa doloremque non rerum enim.",
 		},
 	}
 

--- a/handler/parse_test.go
+++ b/handler/parse_test.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"fmt"
+	"net/url"
 	"testing"
 )
 
@@ -16,6 +18,7 @@ var samples = []struct { //nolint:gochecknoglobals
 	{"key[subkey] [value][]", []string{"key", "subkey", "value", ""}},
 	{"key [ subkey ] [ value ] [ ]", []string{"key", "subkey", "value", ""}},
 	{"ключь [ subkey ] [ value ] [ ]", []string{"ключь", "subkey", "value", ""}}, // test non 1-byte symbols
+	{"options[0][name]", []string{"options", "0", "name"}},
 }
 
 func Test_FetchIndexes(t *testing.T) {
@@ -49,4 +52,107 @@ func same(in, out []string) bool {
 	}
 
 	return true
+}
+
+func TestPushWithMultipleLevelPostData(t *testing.T) {
+	postForm := url.Values{
+		"id": []string{
+			"97b27435-38e3-44d2-b97b-89d82fd6c212",
+		},
+		"options": []string{
+			"",
+		},
+		"options[0][id]": []string{
+			"97b27435-3cb7-40f1-9637-e406465e63ed",
+		},
+		"options[0][name]": []string{
+			"Reiciendis et impedit quod id.",
+		},
+		"options[0][value]": []string{
+			"",
+		},
+		"options[1][id]": []string{
+			"97b27435-3d8a-4f68-b034-88ef3b6cd161",
+		},
+		"options[1][name]": []string{
+			"Mollitia aut assumenda non tempora.",
+		},
+		"options[1][value]": []string{
+			"",
+		},
+		"options[2][id]": []string{
+			"97b27435-3e5a-461a-abee-3c7b3d50ef14",
+		},
+		"options[2][value]": []string{
+			"",
+		},
+		"options[2][name]": []string{
+			"Libero ipsa doloremque non rerum enim.",
+		},
+	}
+
+	d := make(dataTree)
+	for k, v := range postForm {
+		d.push(k, v)
+	}
+	optionDataTree := d["options"].(dataTree)
+	if len(optionDataTree) != 3 {
+		t.Fatal(fmt.Sprintf("invalid length of options: %+v", optionDataTree))
+	}
+	for k, v := range optionDataTree {
+		if len(v.(dataTree)) != 3 {
+			t.Fatal(fmt.Sprintf("invalid length of options[%s]: %+v", k, v))
+		}
+	}
+}
+
+func TestPushWithMultipleLevelFileUpload(t *testing.T) {
+	postForm := map[string][]*FileUpload{
+		"id": {
+			&FileUpload{
+				Name: "file-upload-id",
+			},
+		},
+		"options": nil,
+		"options[0][id]": {
+			&FileUpload{
+				Name: "file-upload-0-id",
+			},
+		},
+		"options[0][name]": {
+			&FileUpload{
+				Name: "file-upload-0-name",
+			},
+		},
+		"options[0][value]": {
+			nil,
+		},
+		"options[1][id]": {
+			&FileUpload{
+				Name: "file-upload-1-id",
+			},
+		},
+		"options[1][name]": {
+			&FileUpload{
+				Name: "file-upload-1-name",
+			},
+		},
+		"options[1][value]": {
+			nil,
+		},
+	}
+
+	d := make(fileTree)
+	for k, v := range postForm {
+		d.push(k, v)
+	}
+	optionFileTree := d["options"].(fileTree)
+	if len(optionFileTree) != 2 {
+		t.Fatal(fmt.Sprintf("invalid length of options: %+v", optionFileTree))
+	}
+	for k, v := range optionFileTree {
+		if len(v.(fileTree)) != 3 {
+			t.Fatal(fmt.Sprintf("invalid length of options[%s]: %+v", k, d))
+		}
+	}
 }

--- a/handler/request.go
+++ b/handler/request.go
@@ -94,7 +94,10 @@ func request(r *http.Request, req *Request, uid, gid int, sendRawBody bool) erro
 			return err
 		}
 
-		req.Uploads = parseUploads(r, uid, gid)
+		req.Uploads, err = parseUploads(r, uid, gid)
+		if err != nil {
+			return err
+		}
 		fallthrough
 	case contentURLEncoded:
 		if sendRawBody {
@@ -117,7 +120,10 @@ func request(r *http.Request, req *Request, uid, gid int, sendRawBody bool) erro
 			return err
 		}
 
-		req.body = parseData(r)
+		req.body, err = parseData(r)
+		if err != nil {
+			return err
+		}
 	}
 
 	req.Parsed = true


### PR DESCRIPTION
# Reason for This PR

when http request has nested level of data then there will be panic in function `mount` of `dataTree` structure

## Description of Changes

this PR make the `mount` function be able to handle such edge case. Test cases are provided in the PR

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
