### PR TITLE
chore: better IP address parsing (IPv6)

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,11 +13,11 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4 # action page: <https://github.com/actions/setup-go>
         with:
-          go-version: 1.19
+          go-version: stable
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v3.4.0 # Action page: <https://github.com/golangci/golangci-lint-action>
         with:
-          version: v1.50 # without patch version
+          version: v1.52 # without patch version
           only-new-issues: false # show only new issues if it's a pull request
           args: --timeout=10m --build-tags=race

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,8 +26,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        go: ["1.19"]
-        os: ["ubuntu-latest"]
+        go: [ stable ]
+        os: [ "ubuntu-latest" ]
     steps:
       - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v4 # action page: <https://github.com/actions/setup-go>

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,6 @@ github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zk
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/mholt/acmez v1.1.0 h1:IQ9CGHKOHokorxnffsqDvmmE30mDenO1lptYZ1AYkHY=
 github.com/mholt/acmez v1.1.0/go.mod h1:zwo5+fbLLTowAX8o8ETfQzbDtwGEXnPhkmGdKIP+bgs=
-github.com/miekg/dns v1.1.52 h1:Bmlc/qsNNULOe6bpXcUTsuOajd0DzRHwup6D9k1An0c=
-github.com/miekg/dns v1.1.52/go.mod h1:uInx36IzPl7FYnDcMeVWxj9byh7DutNykX4G9Sj60FY=
 github.com/miekg/dns v1.1.53 h1:ZBkuHr5dxHtB1caEOlZTLPo7D3L3TWckgUUs/RHfDxw=
 github.com/miekg/dns v1.1.53/go.mod h1:uInx36IzPl7FYnDcMeVWxj9byh7DutNykX4G9Sj60FY=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=

--- a/handler/request.go
+++ b/handler/request.go
@@ -65,12 +65,17 @@ func FetchIP(pair string, log *zap.Logger) string {
 	}
 
 	addr, _, err := net.SplitHostPort(pair)
-	if err != nil {
-		log.Warn("remote address parsing failure", zap.Error(err))
+	if err == nil {
+		return addr
+	}
+
+	ip := net.ParseIP(pair)
+	if ip == nil {
+		log.Warn("remote address parsing failure", zap.Error(err)) // error from the SplitHostPort
 		return ""
 	}
 
-	return addr
+	return ip.String()
 }
 
 func request(r *http.Request, req *Request, uid, gid int, sendRawBody bool) error {


### PR DESCRIPTION
# Reason for This PR

ref: https://github.com/orgs/roadrunner-server/discussions/1516

## Description of Changes

- CF/XFF headers parsed by the `proxy_ip_parser` middleware set the `RemoteAddr` to the IPv6 address without brackets.
- If we have such an address, which is still a valid IP, we use an additional function to verify it with the `net.ParseIP` function.

refs:
- https://www.rfc-editor.org/rfc/rfc5952#section-6
- https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
