### PR TITLE
fix: double config marshaling

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -88,14 +88,8 @@ func (p *Plugin) Init(cfg common.Configurer, rrLogger common.Logger, srv common.
 	if !cfg.Has(PluginName) {
 		return errors.E(op, errors.Disabled)
 	}
-
-	// unmarshal general section
-	err := cfg.UnmarshalKey(PluginName, &p.cfg)
-	if err != nil {
-		return errors.E(op, err)
-	}
-
-	// unmarshal HTTP section
+    
+	// unmarshal HTTP (general) section
 	err = cfg.UnmarshalKey(PluginName, &p.cfg)
 	if err != nil {
 		return errors.E(op, err)


### PR DESCRIPTION
# Reason for This PR

[Issue #1451](https://github.com/roadrunner-server/roadrunner/issues/1541)

## Description of Changes

Removing the second marshalling of the main (http) section.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

- [ ] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
