### PR TITLE
fix: Fix datatree structure

### DIFF
--- a/handler/parse.go
+++ b/handler/parse.go
@@ -106,7 +106,16 @@ func (dt dataTree) mount(keys, v []string) error {
 		return nil
 	}
 
-	return dt[keys[0]].(dataTree).mount(keys[1:], v)
+	res, ok := dt[keys[0]].(dataTree)
+	if !ok {
+		dt[keys[0]] = make(dataTree, 1)
+		res, ok = dt[keys[0]].(dataTree)
+		if !ok {
+			return nil
+		}
+	}
+
+	return res.mount(keys[1:], v)
 }
 
 func prepareTreeNode[T dataTree | fileTree, V []string | []*FileUpload](tree T, i []string, v V) (bool, error) {

--- a/handler/parse_test.go
+++ b/handler/parse_test.go
@@ -69,6 +69,104 @@ func TestDataTreePush(t *testing.T) {
 		wantErr error
 	}{
 		{
+			name: "the longest chain is visible in tree structure",
+			values: orderedData{
+				{
+					key:   "key[questions][2]",
+					value: []string{""},
+				},
+				{
+					key:   "key[questions][2][answers][3][clue]",
+					value: []string{""},
+				},
+			},
+			wantVal: dataTree{
+				"questions": dataTree{
+					"2": dataTree{
+						"answers": dataTree{
+							"3": dataTree{
+								"clue": "",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "values from chain which contains shorter chains will have high priority",
+			values: orderedData{
+
+				{
+					key:   "key[questions][10][answers][3][clue]",
+					value: []string{"wwwww"},
+				},
+				{
+					key:   "key[questions][10]",
+					value: []string{""},
+				},
+				{
+					key:   "key[questions][10][answers][4][clue]",
+					value: []string{"12345"},
+				},
+			},
+			wantVal: dataTree{
+				"questions": dataTree{
+					"10": dataTree{
+						"answers": dataTree{
+							"3": dataTree{
+								"clue": "wwwww",
+							},
+							"4": dataTree{
+								"clue": "12345",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "chain with same prefix and empty value should be overwriteen by full path",
+			values: orderedData{
+				{
+					key:   "key[questions][5]",
+					value: []string{""},
+				},
+				{
+					key:   "key[questions][5][answers][3]",
+					value: []string{""},
+				},
+				{
+					key:   "key[questions][5][answers][3][clue]",
+					value: []string{"xxxxx"},
+				},
+			},
+			wantVal: dataTree{
+				"questions": dataTree{
+					"5": dataTree{
+						"answers": dataTree{
+							"3": dataTree{
+								"clue": "xxxxx",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "chains with similar structure should fail when all has assigned value",
+			values: orderedData{
+				{
+					key:   "key[questions][5]",
+					value: []string{"1"},
+				},
+				{
+					key:   "key[questions][5][answers][3][clue]",
+					value: []string{"2"},
+				},
+			},
+			wantErr: errors.New("invalid multiple values to key '5' in tree"),
+		},
+		{
 			name: "non associated array should stay",
 			values: orderedData{
 				{


### PR DESCRIPTION
# Reason for This PR

closes: https://github.com/roadrunner-server/roadrunner/issues/1765

## Description of Changes

In some cases, chain like `key[questions][2]` has value assigned as `interface {}(string) ""` so if next chain was `key[questions][2][answers][3][clue]` there was no ability to continue already started chain since to continue requested is dataTree structure.

I verified both response from apache/nginx and rr for example of request and response structure looks identical.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data handling capabilities with dynamic creation of nested structures during the mounting process.
- **Tests**
	- Introduced new test cases to ensure robustness and reliability of data handling, covering a variety of scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->