### PR TITLE
chore: show errors in browser in debug mode

### DIFF
--- a/tests/configs/.rr-debugmode-fail.yaml
+++ b/tests/configs/.rr-debugmode-fail.yaml
@@ -1,0 +1,33 @@
+version: '3'
+
+rpc:
+  listen: tcp://127.0.0.1:6065
+
+server:
+  command: "php php_test_files/worker-debugmode-fail.php"
+  relay: "pipes"
+
+http:
+  address: 127.0.0.1:19995
+  max_request_size: 1024
+  uploads:
+    forbid: [".php", ".exe", ".bat"]
+  trusted_subnets:
+    [
+      "10.0.0.0/8",
+      "127.0.0.0/8",
+      "172.16.0.0/12",
+      "192.168.0.0/16",
+      "::1/128",
+      "fc00::/7",
+      "fe80::/10",
+    ]
+  pool:
+    num_workers: 1
+    debug: true
+    allocate_timeout: 60s
+    destroy_timeout: 1s
+
+logs:
+  mode: development
+  level: debug

--- a/tests/php_test_files/worker-debugmode-fail.php
+++ b/tests/php_test_files/worker-debugmode-fail.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @var Goridge\RelayInterface $relay
+ */
+use Spiral\Goridge;
+use Spiral\RoadRunner;
+
+ini_set('display_errors', 'stderr');
+require __DIR__ . "/vendor/autoload.php";
+
+
+$worker = RoadRunner\Worker::create();
+$psr7 = new RoadRunner\Http\PSR7Worker(
+    $worker,
+    new \Nyholm\Psr7\Factory\Psr17Factory(),
+    new \Nyholm\Psr7\Factory\Psr17Factory(),
+    new \Nyholm\Psr7\Factory\Psr17Factory()
+);
+
+while ($req = $psr7->waitRequest()) {
+    try {
+        throw new Exception('test');
+    } catch (\Throwable $e) {
+        $psr7->getWorker()->error((string)$e);
+    }
+}


### PR DESCRIPTION
# Reason for This PR

- closes: https://github.com/roadrunner-server/roadrunner/issues/1781

## Description of Changes

- Show worker errors in the HTTP response in the `pool.debug=true` mode.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `debugMode` for enhanced error reporting during development.

- **Tests**
  - Added tests to verify server behavior in `debugMode`.

- **Documentation**
  - Included a new configuration file example for setting up the service in debug mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->