### PR TITLE
chore: Adjust JSON schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -142,12 +142,12 @@
           }
         },
         "request": {
-          "description": "Headers to add to every request passed to PHP.",
-          "$ref": "#/$defs/HashmapString"
+          "description": "Customer HTTP headers to add to every request passed to PHP.",
+          "$ref": "#/$defs/Headers"
         },
         "response": {
-          "description": "Headers added to every response.",
-          "$ref": "#/$defs/HashmapString"
+          "description": "Customer HTTP headers to add to every response from PHP.",
+          "$ref": "#/$defs/Headers"
         }
       }
     },
@@ -201,13 +201,13 @@
           "type": "boolean",
           "default": false
         },
-        "response": {
-          "description": "Custom HTTP headers to add to responses to requests for static files.",
-          "$ref": "#/$defs/HashmapString"
-        },
         "request": {
-          "description": "Custom HTTP headers to add to requests for static files.",
-          "$ref": "#/$defs/HashmapString"
+          "description": "Custom HTTP headers to add to every request for static files.",
+          "$ref": "#/$defs/Headers"
+        },
+        "response": {
+          "description": "Custom HTTP headers to add to every response from static files.",
+          "$ref": "#/$defs/Headers"
         }
       }
     },
@@ -222,6 +222,9 @@
     },
     "http2": {
       "$ref": "#/$defs/HTTP2"
+    },
+    "http3": {
+      "$ref": "#/$defs/HTTP3"
     }
   },
   "$defs": {
@@ -464,8 +467,41 @@
         }
       }
     },
-    "HashmapString": {
-      "$ref": "https://raw.githubusercontent.com/roadrunner-server/roadrunner/refs/heads/master/schemas/config/3.0.schema.json#/definitions/HashmapString"
+    "HTTP3": {
+      "description": "HTTP/3 settings. **Experimental**: Requires that RoadRunner has experimental features enabled. Unless you configured `acme`, you must provide a `key` and `cert` here.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "address"
+      ],
+      "properties": {
+        "address": {
+          "description": "Host and/or port to listen on for HTTP/3.",
+          "type": "string",
+          "minLength": 1,
+          "examples": [
+            "127.0.0.1:8080",
+            ":8080"
+          ]
+        },
+        "cert": {
+          "$ref": "#/$defs/SSL/properties/cert"
+        },
+        "key": {
+          "$ref": "#/$defs/SSL/properties/key"
+        }
+      }
+    },
+    "Headers": {
+      "type": "object",
+      "minProperties": 1,
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
     }
   }
 }

--- a/schema.json
+++ b/schema.json
@@ -142,11 +142,11 @@
           }
         },
         "request": {
-          "description": "Customer HTTP headers to add to every request passed to PHP.",
+          "description": "Custom HTTP headers to add to every request passed to PHP.",
           "$ref": "#/$defs/Headers"
         },
         "response": {
-          "description": "Customer HTTP headers to add to every response from PHP.",
+          "description": "Custom HTTP headers to add to every response from PHP.",
           "$ref": "#/$defs/Headers"
         }
       }
@@ -474,6 +474,14 @@
       "required": [
         "address"
       ],
+      "dependentRequired": {
+        "cert": [
+          "key"
+        ],
+        "key": [
+          "cert"
+        ]
+      },
       "properties": {
         "address": {
           "description": "Host and/or port to listen on for HTTP/3.",


### PR DESCRIPTION
Add documentation for HTTP3 experimental

# Reason for This PR

Followup to consolidated schemas. Also the HTTP3 section was missing.

## Description of Changes

Adjusted schema; dereferenced `HashmapString` from main repo
Added HTTP 3 schema (with experimental warning)

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for HTTP/3 settings, enhancing performance and capabilities.
	- Added a new `Headers` definition to improve header management.

- **Improvements**
	- Clarified descriptions for custom HTTP headers in requests and responses.
	- Updated `trusted_subnets` with default values for common private networks.
	- Enhanced clarity for `max_request_size` and `internal_error_code` properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->